### PR TITLE
Providing better error message and location

### DIFF
--- a/lib/fail.js
+++ b/lib/fail.js
@@ -3,6 +3,7 @@ var match = require('pattern-match');
 function ValidationError(message, stack) {
     Error.call(this, message);
     this.stack = stack;
+    this.message = message;
 }
 
 ValidationError.prototype = Object.create(Error.prototype);

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -129,7 +129,7 @@ Vp.match = function(node, desc, body) {
     function failWithLocation(e) {
         if (e instanceof match.MatchError) {
             var loc = e && e.actual ? e.actual.loc : null;
-            self.fail("invalid " + desc + fail.locToString(loc), loc);
+            self.fail("invalid " + desc, loc);
         } else {
             throw e;
         }

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -105,34 +105,35 @@ var Vp = Validator.prototype;
 // (AST, string[, Function]) -> any
 // Delegates to pattern-match library, converting MatchErrors to validation errors.
 Vp.match = function(node, desc, body) {
+    var self = this;
     if (body) {
         try {
             return match(node, body, this);
         } catch (e) {
-            if (e instanceof match.MatchError)
-                this.fail("invalid " + desc);
-            else
-                throw e;
+            failWithLocation(e);
         }
     }
 
     var delayed = match(node);
-    var self = this;
 
     return {
         when: function(pattern, template) {
             try {
                 return delayed.when(pattern, template, self);
             } catch (e) {
-                if (e instanceof match.MatchError) {
-                    var loc = e && e.actual ? e.actual.loc : null;
-                    self.fail("invalid " + desc + fail.locToString(loc), loc);
-                } else {
-                    throw e;
-                }
+                failWithLocation(e);
             }
         }
     };
+
+    function failWithLocation(e) {
+        if (e instanceof match.MatchError) {
+            var loc = e && e.actual ? e.actual.loc : null;
+            self.fail("invalid " + desc + fail.locToString(loc), loc);
+        } else {
+            throw e;
+        }
+    }
 };
 
 // (string) -> Report


### PR DESCRIPTION
I noticed that Error message is not visible on `ValidationError` instance, even though you call `Error.call(this, message);`

There also was one place with missing location information, so code like this fails with empty location:

``` js
function helloWorld(stdlib, foreign, heap) {
  "use asm";

  // this is what we're validating
  function giveThemTheAnswer() {
    var y = 42-0; // <-- error!
    return y|0;
  }
  return { answer: giveThemTheAnswer };
}
```