### PR TITLE
Add validator

### DIFF
--- a/bin/asmjs
+++ b/bin/asmjs
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+
+var path = require('path');
+var argv = require('minimist')(process.argv.slice(2));
+var colors = require('colors/safe');
+var asm = require('../lib/asm.js');
+var fs = require('fs');
+
+var exitCode = 0;
+
+if (argv.help || argv._.length === 0) {
+    return fs.createReadStream(__dirname + '/usage.txt')
+        .pipe(process.stdout)
+        .on('close', function () {
+            process.exit(1);
+        })
+    ;
+}
+
+var files = argv._;
+
+if (files.length === 0) {
+    exitCode = 1;
+    console.error(colors.red('No matching files found'));
+}
+
+files.forEach(function (file) {
+    process.stdout.write('Validating ' + file + '...');
+    var module = require(path.resolve(process.cwd(), file));
+    if (typeof module !== 'function') {
+        console.error(colors.red(' Error!'));
+        console.error(colors.red(file + ' needs to export a single function'));
+        exitCode = 1;
+        return;
+    }
+    var source = String(module);
+    try {
+        asm.validate(source);
+        console.log(colors.green(' Success!'));
+    } catch (error) {
+        console.log(colors.red(' Error!'));
+        console.error(colors.red(error.stack));
+        exitCode = 1;
+    }
+});
+
+if (exitCode === 0) {
+    console.log(colors.grey('---'));
+    console.log(colors.green('No validation errors found'));
+}
+
+process.exit(exitCode);

--- a/bin/usage.txt
+++ b/bin/usage.txt
@@ -1,0 +1,7 @@
+Usage: asmjs [entry files] {OPTIONS}
+
+Standard Options:
+
+    --help, -h  Show this message
+
+Specify a parameter.

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "esprima": "1.0.4",
-    "dict": "1.4.0",
     "array-extended": "0.0.4",
+    "colors": "^1.0.3",
+    "dict": "1.4.0",
+    "esprima": "1.0.4",
+    "minimist": "^1.1.0",
     "pattern-match": "0.3.0"
   },
   "devDependencies": {
@@ -21,6 +23,9 @@
   },
   "directories": {
     "lib": "./lib"
+  },
+  "bin": {
+    "asmjs": "./bin/asmjs"
   },
   "repository": {
     "type": "git",
@@ -32,6 +37,7 @@
     "validator"
   ],
   "scripts": {
-    "test": "nodeunit"
-  }
+    "test": "nodeunit && ./test/asmjs.sh"
+  },
+  "preferGlobal": true
 }

--- a/test/asmjs.sh
+++ b/test/asmjs.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+VALID_FILES=${DIR}/valid/*.js
+
+for f in $VALID_FILES
+do
+    ./bin/asmjs $f
+    if [ $? -ne 0 ]; then
+        exit 1
+    fi
+done
+
+INVALID_FILES=${DIR}/invalid/*.js
+
+for f in $INVALID_FILES
+do
+    ./bin/asmjs $f
+    if [ $? -ne 1 ]; then
+        exit 1
+    fi
+done

--- a/test/invalid/GeometricMean-no-export.js
+++ b/test/invalid/GeometricMean-no-export.js
@@ -1,0 +1,30 @@
+function GeometricMean(stdlib, foreign, buffer) {
+  "use asm";
+
+  var exp = stdlib.Math.exp;
+  var log = stdlib.Math.log;
+  var values = new stdlib.Float64Array(buffer);
+
+  function logSum(start, end) {
+    start = start|0;
+    end = end|0;
+
+    var sum = 0.0, p = 0, q = 0;
+
+    // asm.js forces byte addressing of the heap by requiring shifting by 3
+    for (p = start << 3, q = end << 3; (p|0) < (q|0); p = (p + 8)|0) {
+      sum = sum + +log(values[p>>3]);
+    }
+
+    return +sum;
+  }
+
+  function geometricMean(start, end) {
+    start = start|0;
+    end = end|0;
+
+    return +exp(+logSum(start, end) / +((end - start)|0));
+  }
+
+  return { geometricMean: geometricMean };
+}

--- a/test/invalid/GeometricMean-type.js
+++ b/test/invalid/GeometricMean-type.js
@@ -1,0 +1,32 @@
+function GeometricMean(stdlib, foreign, buffer) {
+  "use asm";
+
+  var exp = stdlib.Math.exp;
+  var log = stdlib.Math.log;
+  var values = new stdlib.Float64Array(buffer);
+
+  function logSum(start, end) {
+    start = start|0;
+    end = end|0;
+
+    var sum = 0, p = 0, q = 0;
+
+    // asm.js forces byte addressing of the heap by requiring shifting by 3
+    for (p = start << 3, q = end << 3; (p|0) < (q|0); p = (p + 8)|0) {
+      sum = sum + +log(values[p>>3]);
+    }
+
+    return +sum;
+  }
+
+  function geometricMean(start, end) {
+    start = start|0;
+    end = end|0;
+
+    return +exp(+logSum(start, end) / +((end - start)|0));
+  }
+
+  return { geometricMean: geometricMean };
+}
+
+module.exports = GeometricMean;

--- a/test/valid/GeometricMean-common.js
+++ b/test/valid/GeometricMean-common.js
@@ -1,0 +1,32 @@
+function GeometricMean(stdlib, foreign, buffer) {
+  "use asm";
+
+  var exp = stdlib.Math.exp;
+  var log = stdlib.Math.log;
+  var values = new stdlib.Float64Array(buffer);
+
+  function logSum(start, end) {
+    start = start|0;
+    end = end|0;
+
+    var sum = 0.0, p = 0, q = 0;
+
+    // asm.js forces byte addressing of the heap by requiring shifting by 3
+    for (p = start << 3, q = end << 3; (p|0) < (q|0); p = (p + 8)|0) {
+      sum = sum + +log(values[p>>3]);
+    }
+
+    return +sum;
+  }
+
+  function geometricMean(start, end) {
+    start = start|0;
+    end = end|0;
+
+    return +exp(+logSum(start, end) / +((end - start)|0));
+  }
+
+  return { geometricMean: geometricMean };
+}
+
+module.exports = GeometricMean;

--- a/test/valid/GeometricMean-umd.js
+++ b/test/valid/GeometricMean-umd.js
@@ -1,0 +1,44 @@
+function GeometricMean(stdlib, foreign, buffer) {
+  "use asm";
+
+  var exp = stdlib.Math.exp;
+  var log = stdlib.Math.log;
+  var values = new stdlib.Float64Array(buffer);
+
+  function logSum(start, end) {
+    start = start|0;
+    end = end|0;
+
+    var sum = 0.0, p = 0, q = 0;
+
+    // asm.js forces byte addressing of the heap by requiring shifting by 3
+    for (p = start << 3, q = end << 3; (p|0) < (q|0); p = (p + 8)|0) {
+      sum = sum + +log(values[p>>3]);
+    }
+
+    return +sum;
+  }
+
+  function geometricMean(start, end) {
+    start = start|0;
+    end = end|0;
+
+    return +exp(+logSum(start, end) / +((end - start)|0));
+  }
+
+  return { geometricMean: geometricMean };
+}
+
+// [UMD pattern](https://github.com/umdjs/umd)
+// used for making this module work with Node, AMD and browser globals
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define([], factory);
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
+    } else {
+        root.returnExports = factory();
+  }
+}(this, function () {
+    return GeometricMean;
+}));


### PR DESCRIPTION
#101 

`npm test` wasn't doing anything for me:

```
npm test

> asm.js@0.0.3 test /Users/alexandergugel/repos/asm.js
> nodeunit

Files required.
Usage: nodeunit [options] testmodule1.js testfolder [...] 
Options:

  --config FILE     the path to a JSON file with options
  --reporter FILE   optional path to a reporter file to customize the output
  --list-reporters  list available build-in reporters
  -t name,          specify a test to run
  -f fullname,      specify a specific test to run. fullname is built so: "outerGroup - .. - innerGroup - testName"
  -h, --help        display this help and exit
  -v, --version     output version information and exit
npm ERR! Test failed.  See above for more details.
```

I added a few rough tests for the command line utility (copied over from [`validate-asm`](https://github.com/alexanderGugel/validate-asm)).

Please let me know what you think.

Thanks.