### PR TITLE
Conditional expression validation should consider subtypes of int/double

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -865,10 +865,18 @@ Vp.expression = function expression(e) {
             this.checkSubtype(this.expression(vars.test), ty.Int, "conditional test", vars.test.loc);
             var t1 = this.expression(vars.cons);
             var t2 = this.expression(vars.alt);
-            if (t1 !== t2)
-                this.fail("type mismatch between conditional branches", e.loc);
-            if (t1 !== ty.Int && t1 !== ty.Double)
+
+            var t1supertype;
+            if (t1.subtype(ty.Int)) {
+                t1supertype = ty.Int;
+            } else if (t1.subtype(ty.Double)) {
+                t1supertype = ty.Double;
+            } else {
                 this.fail("expected int or double in conditional branch, got " + t1, vars.cons.loc);
+            }
+
+            if (!t2.subtype(t1supertype))
+                this.fail("type mismatch between conditional branches", e.loc);
             return t1;
         }, this);
 

--- a/test/index.js
+++ b/test/index.js
@@ -301,3 +301,24 @@ exports.testFunctionTables = asmAssert(
         var x = [f], y = [g], z = [f, g]
         return f;
     }, { pass: true });
+
+exports.testConditionalExpression = asmAssert.one(
+    "conditional expression",
+    function f() {
+        return (1 ? 2 : 3)|0;
+    },
+    { pass: true });
+
+exports.testConditionalExpressionMismatchedTypes = asmAssert.one(
+    "conditional with consequent and alternate of differing types",
+    function f() {
+        return (1 ? 0.5 : 3)|0;
+    },
+    { pass: false });
+
+exports.testConditionalExpressionDifferentSubtypes = asmAssert.one(
+    "conditional with different subtypes of int",
+    function f() {
+        return (1 ? (2 < 3) : 4)|0;
+    },
+    { pass: true });


### PR DESCRIPTION
Validation of ConditionalExpression currently rejects some valid cases, because it expects the consequent and alternate expressions to match the Int or Double type exactly; as per http://asmjs.org/spec/latest/#conditionalexpression, it should accept any subtype of Int / Double.

This PR corrects the logic so that the two expressions must either be both subtypes of Int, OR both subtypes of Double.