### PR TITLE
Restrict min + max to signed.

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -77,6 +77,10 @@ optimizing implementation of this draft.
 </p><h3 class="no-num no-toc" id=changelog>Changelog</h3>
 
 <ul>
+<li><strong>16 March 2016</strong>
+  <ul>
+    <li>Restrict Math.min + Math.max to signed.
+  </li></ul>
 <li><strong>18 August 2014</strong>
   <ul>
     <li>better "putting it all together" example
@@ -2196,7 +2200,7 @@ Expressions</a>.
     <code>Math.max</code>
   </td>
   <td>
-    (<a href=#int-0><code>int</code></a>, <a href=#int-0><code>int</code></a><code>…</code>) → <a href=#signed-0><code>signed</code></a> ∧<br>
+    (<a href=#signed-0><code>signed</code></a>, <a href=#signed-0><code>signed</code></a><code>…</code>) → <a href=#signed-0><code>signed</code></a> ∧<br>
     (<a href=#double-1><code>double</code></a>, <a href=#double-1><code>double</code></a><code>…</code>) → <a href=#double-1><code>double</code></a>
   </td>
 </tr>

--- a/test/index.js
+++ b/test/index.js
@@ -279,6 +279,32 @@ exports.testMaxWrongArgumentType = asmAssert(
         return f;
     }, { pass: false });
 
+exports.testMinWrongArgumentType2 = asmAssert(
+    "unsigned is not a subtype of signed",
+    function m(stdlib, foreign, heap) {
+        "use asm";
+        var min = stdlib.Math.min;
+        function f(i0, i1) {
+            i0 = i0|0;
+            i1 = i1|0;
+            min(i0>>>0, i1>>>0)|0;
+        }
+        return f;
+    }, { pass: false });
+
+exports.testMaxWrongArgumentType2 = asmAssert(
+    "unsigned is not a subtype of signed",
+    function m(stdlib, foreign, heap) {
+        "use asm";
+        var max = stdlib.Math.max;
+        function f(i0, i1) {
+            i0 = i0|0;
+            i1 = i1|0;
+            max(i0>>>0, i1>>>0)|0;
+        }
+        return f;
+    }, { pass: false });
+
 exports.testMaxWrongReturnType = asmAssert(
     "min argument types don't match",
     function m(stdlib, foreign, heap) {


### PR DESCRIPTION
Current firefox seems to restrict these to signed.
Allowing any int would seem to be problematic, unless all the args are required to be all unsigned or all signed.
